### PR TITLE
Fix: UART hangs waiting for TXDRDY event

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -79,11 +79,11 @@ impl hal::serial::Read<u8> for Rx<UART0> {
         match uart.events_rxdrdy.read().bits() {
             0 => Err(nb::Error::WouldBlock),
             _ => {
-                // Read one 8bit value
-                let byte = uart.rxd.read().bits() as u8;
-
                 // Reset ready for receive event
                 uart.events_rxdrdy.reset();
+
+                // Read one 8bit value
+                let byte = uart.rxd.read().bits() as u8;
 
                 Ok(byte)
             }
@@ -102,11 +102,11 @@ impl hal::serial::Write<u8> for Tx<UART0> {
         let uart = unsafe { &*UART0::ptr() };
         // Are we ready for sending out next byte?
         if uart.events_txdrdy.read().bits() == 1 {
-            // Send byte
-            uart.txd.write(|w| unsafe { w.bits(u32::from(byte)) });
-
             // Reset ready for transmit event
             uart.events_txdrdy.reset();
+
+            // Send byte
+            uart.txd.write(|w| unsafe { w.bits(u32::from(byte)) });
 
             Ok(())
         } else {


### PR DESCRIPTION
I'm using this crate on the MicroBit and this issue is something that started happening after I enabled the SoftDevice. UART would print half of the message and then hang there indefinitely. It's obvious what's happening in retrospect, but it sure didn't seem that way before hours of debugging.

What's happening is that the SoftDevice is triggering quite a lot of interrupts and doing its work while the main thread is paused. If it just so happens that the interrupt is triggered after the `Send byte`, but before the `Reset TXD ready` line, it's possible that the UART hardware will be done with writing the byte by the time the interrupt returns and already set the TXD ready flag, and upon return, it will be cleared and never set again. The fix is trivial - just change the order of those two operations so the TXD ready flag is cleared before the next write.

I'm kind of extrapolating that the same issue happens with the RX part though I'm not using it and didn't experience it.