### PR TITLE
Drivers for the TIMER and RTC peripherals

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -5,7 +5,96 @@ use nrf51::TIMER0;
 
 use hal::blocking::delay::{DelayMs, DelayUs};
 
-use crate::hi_res_timer::{HiResTimer, As32BitTimer, TimerCc};
+use crate::hi_res_timer::{HiResTimer, Nrf51Timer, TimerCc, TimerWidth};
+
+/// A TIMER peripheral as a delay provider.
+///
+/// `DelayTimer` instances implement the embedded-hal `DelayMs` and `DelayUs`
+/// traits (for `u8`, `u16`, and `u32`).
+///
+/// # Panics
+///
+/// `delay_ms()` and `delay_us()` panic if the requested time requires more
+/// 1mHz ticks than can be represented using the timer's bit-width (32-bit for
+/// TIMER0, giving approximately 71 minutes; 16-bit otherwise, giving
+/// approximately 65ms).
+///
+/// # Example
+/// ```
+/// use embedded_hal::delay::DelayMs;
+/// use nrf51_hal::delay::DelayTimer;
+/// let p = nrf51::Peripherals::take().unwrap();
+/// let mut timer0 = DelayTimer::new(p.TIMER0);
+/// timer0.delay_ms(1000);
+/// ```
+pub struct DelayTimer<T: Nrf51Timer> {
+    timer: HiResTimer<T, T::MaxWidth>,
+}
+
+impl<T: Nrf51Timer> DelayTimer<T> {
+    /// Returns a new `DelayTimer` wrapping the passed TIMER.
+    ///
+    /// Takes ownership of the TIMER peripheral.
+    ///
+    /// The TIMER is set to the greatest bit-width it supports, and the
+    /// default 1MHz frequency.
+    pub fn new(timer: T) -> Self {
+        let mut hi_res_timer = timer.as_max_width_timer();
+        hi_res_timer.enable_auto_stop(TimerCc::CC0);
+        DelayTimer { timer: hi_res_timer }
+    }
+
+    /// Gives the underlying `nrf51::TIMER`*n* instance back.
+    pub fn free(self) -> T {
+        self.timer.free()
+    }
+
+    fn delay(&mut self, us: u32) {
+        let ticks = T::MaxWidth::try_from_u32(us).expect("TIMER compare value too wide");
+        self.timer.clear();
+        // Default frequency is 1MHz, so we can use microseconds as ticks
+        self.timer.set_compare_register(TimerCc::CC0, ticks);
+        self.timer.start();
+        while !self.timer.poll_compare_event(TimerCc::CC0) {}
+    }
+}
+
+impl<T: Nrf51Timer> DelayMs<u32> for DelayTimer<T> {
+    fn delay_ms(&mut self, ms: u32) {
+        self.delay(ms.checked_mul(1000).expect("ms delay out of range"));
+    }
+}
+
+impl<T: Nrf51Timer> DelayMs<u16> for DelayTimer<T> {
+    fn delay_ms(&mut self, ms: u16) {
+        self.delay(u32(ms) * 1000);
+    }
+}
+
+impl<T: Nrf51Timer> DelayMs<u8> for DelayTimer<T> {
+    fn delay_ms(&mut self, ms: u8) {
+        self.delay(u32(ms) * 1000);
+    }
+}
+
+impl<T: Nrf51Timer> DelayUs<u32> for DelayTimer<T> {
+    fn delay_us(&mut self, us: u32) {
+        self.delay(us);
+    }
+}
+
+impl<T: Nrf51Timer> DelayUs<u16> for DelayTimer<T> {
+    fn delay_us(&mut self, us: u16) {
+        self.delay(u32(us));
+    }
+}
+
+impl<T: Nrf51Timer> DelayUs<u8> for DelayTimer<T> {
+    fn delay_us(&mut self, us: u8) {
+        self.delay(u32(us));
+    }
+}
+
 
 /// System timer `TIMER0` as a delay provider.
 ///
@@ -15,69 +104,12 @@ use crate::hi_res_timer::{HiResTimer, As32BitTimer, TimerCc};
 /// `Delay` instances implement the embedded-hal `DelayMs` and `DelayUs`
 /// traits (for `u8`, `u16`, and `u32`).
 ///
+/// `Delay` is provided in addition to `DelayTimer` for backwards
+/// compatibility, and as a simple way to get an implementation of the
+/// embedded-hal delay traits if you don't care about choosing which timer to
+/// use.
+///
 /// # Panics
 ///
 /// `delay_ms()` panics if the requested time exceeds the maximum setting.
-pub struct Delay {
-    timer: HiResTimer<TIMER0, u32>
-}
-
-impl Delay {
-    /// Returns a new `Delay` wrapping TIMER0.
-    ///
-    /// Takes ownership of the TIMER0 peripheral.
-    pub fn new(timer: TIMER0) -> Delay {
-        let mut hi_res_timer = timer.as_32bit_timer();
-        hi_res_timer.enable_auto_stop(TimerCc::CC0);
-        Delay{timer: hi_res_timer}
-    }
-
-    /// Gives the underlying `nrf51::TIMER0` instance back.
-    pub fn free(self) -> TIMER0 {
-        self.timer.free()
-    }
-
-    fn delay(&mut self, us: u32) {
-        self.timer.clear();
-        // Default frequency is 1MHz, so we can use microseconds as ticks
-        self.timer.set_compare_register(TimerCc::CC0, us);
-        self.timer.start();
-        while !self.timer.poll_compare_event(TimerCc::CC0) {}
-    }
-}
-
-impl DelayMs<u32> for Delay {
-    fn delay_ms(&mut self, ms: u32) {
-        self.delay(ms.checked_mul(1000).expect("ms delay out of range"));
-    }
-}
-
-impl DelayMs<u16> for Delay {
-    fn delay_ms(&mut self, ms: u16) {
-        self.delay(u32(ms) * 1000);
-    }
-}
-
-impl DelayMs<u8> for Delay {
-    fn delay_ms(&mut self, ms: u8) {
-        self.delay(u32(ms) * 1000);
-    }
-}
-
-impl DelayUs<u32> for Delay {
-    fn delay_us(&mut self, us: u32) {
-        self.delay(us);
-    }
-}
-
-impl DelayUs<u16> for Delay {
-    fn delay_us(&mut self, us: u16) {
-        self.delay(u32(us));
-    }
-}
-
-impl DelayUs<u8> for Delay {
-    fn delay_us(&mut self, us: u8) {
-        self.delay(u32(us));
-    }
-}
+pub type Delay = DelayTimer<TIMER0>;

--- a/src/hi_res_timer.rs
+++ b/src/hi_res_timer.rs
@@ -10,7 +10,7 @@
 use core::marker::PhantomData;
 use core::ops::Deref;
 
-use cast::{u8, u16};
+use cast::{u8, u16, u32};
 
 use nrf51;
 
@@ -166,6 +166,18 @@ impl TimerFrequency {
             9 => TimerFrequency::Freq31250Hz,
             _ => panic!("prescaler out of range"),
         }
+    }
+
+    /// Apply the effective prescaler value.
+    ///
+    /// Converts a number of ticks of the base 16MHz clock to the equivalent
+    /// number of ticks for a timer using this frequency.
+    ///
+    /// Rounds down.
+    ///
+    /// Returns `None` if the result doesn't fit in a u32.
+    pub fn scale(self, base_ticks: u64) -> Option<u32> {
+        u32(base_ticks >> self as u64).ok()
     }
 }
 

--- a/src/hi_res_timer.rs
+++ b/src/hi_res_timer.rs
@@ -1,0 +1,449 @@
+//! The TIMER peripherals.
+//!
+//! This module provides a interface to the TIMER peripherals, more or less
+//! directly corresponding to the underlying registers, tasks, and events.
+//!
+//! At present only timer mode (as opposed to counter mode) is supported.
+//!
+//! TIMER0's 24-bit mode isn't supported.
+
+use core::marker::PhantomData;
+use core::ops::Deref;
+
+use cast::{u8, u16};
+
+use nrf51;
+
+/// The base frequency of a TIMER, in megahertz.
+///
+/// This is the highest available frequency.
+pub const HFCLK_MHZ: u32 = 16;
+
+/// An unsigned integer type used as the bit-width of a TIMER.
+pub trait TimerWidth: Into<u32> {
+    #[doc(hidden)]
+    /// Set the specified timer to this type's width.
+    fn program_timer<T: Nrf51Timer>(timer: &T);
+
+    #[doc(hidden)]
+    /// Checked conversion of a u32 to this type.
+    fn try_from_u32(val: u32) -> Result<Self, ()>;
+}
+
+impl TimerWidth for u8 {
+    #[doc(hidden)]
+    fn program_timer<T: Nrf51Timer>(timer: &T) {
+        timer.bitmode.write(|w| w.bitmode()._08bit());
+    }
+
+    #[doc(hidden)]
+    fn try_from_u32(val: u32) -> Result<u8, ()> {
+        u8(val).map_err(|_| ())
+    }
+}
+
+impl TimerWidth for u16 {
+    #[doc(hidden)]
+    fn program_timer<T: Nrf51Timer>(timer: &T) {
+        timer.bitmode.write(|w| w.bitmode()._16bit());
+    }
+
+    #[doc(hidden)]
+    fn try_from_u32(val: u32) -> Result<u16, ()> {
+        u16(val).map_err(|_| ())
+    }
+}
+
+impl TimerWidth for u32 {
+    #[doc(hidden)]
+    fn program_timer<T: Nrf51Timer>(timer: &T) {
+        timer.bitmode.write(|w| w.bitmode()._32bit());
+    }
+
+    #[doc(hidden)]
+    fn try_from_u32(val: u32) -> Result<u32, ()> {
+        Ok(val)
+    }
+}
+
+/// One of the nRF51's high-resolution timers (`nrf51::TIMER0`, `nrf51::TIMER1`,
+/// or `nrf51::TIMER2`)
+pub trait Nrf51Timer: Deref<Target = nrf51::timer0::RegisterBlock> + Sized {}
+
+/// One of the TIMER Capture/Compare registers.
+///
+/// Each TIMER has four CC registers.
+#[derive(Copy, Clone, Debug)]
+pub enum TimerCc {
+    CC0 = 0,
+    CC1 = 1,
+    CC2 = 2,
+    CC3 = 3,
+}
+
+impl TimerCc {
+    /// Returns the CC register with the specified index.
+    ///
+    /// Note you can use 'as' to go in the other direction.
+    pub fn from_index(cc: usize) -> Result<TimerCc, ()> {
+        match cc {
+            0 => Ok(TimerCc::CC0),
+            1 => Ok(TimerCc::CC1),
+            2 => Ok(TimerCc::CC2),
+            3 => Ok(TimerCc::CC3),
+            _ => Err(()),
+        }
+    }
+}
+
+/// One of the possible TIMER frequencies.
+///
+/// All three TIMERs support all these frequencies.
+///
+/// TimerFrequency | Period | 16-bit overflow | 32-bit overflow
+/// -------------- | ------ | --------------- | ---------------
+///  `Freq16MHz`   | 62.5ns |    >   4 ms     |  >  4 minutes
+///  `Freq8MHz`    |  125ns |    >   8 ms     |  >  8 minutes
+///  `Freq4MHz`    |  250ns |    >  16 ms     |  > 17 minutes
+///  `Freq2MHz`    |  500ns |    >  32 ms     |  > 35 minutes
+///  `Freq1MHz`    |    1µs |    >  65 ms     |  > 71 minutes
+///  `Freq500kHz`  |    2µs |    > 131 ms     |  >  2 hours
+///  `Freq250kHz`  |    4µs |    > 262 ms     |  >  4 hours
+///  `Freq125kHz`  |    8µs |    > 524 ms     |  >  9 hours
+///  `Freq62500Hz` |   16µs |    >   1 s      |  > 19 hours
+///  `Freq31250Hz` |   32µs |    >   2 s      |  > 38 hours
+
+#[derive(Copy, Clone, Debug)]
+// Labels imitated from Nordic SDK nrf_timer_frequency_t
+pub enum TimerFrequency {
+    Freq16MHz = 0,
+    Freq8MHz = 1,
+    Freq4MHz = 2,
+    Freq2MHz = 3,
+    Freq1MHz = 4,
+    Freq500kHz = 5,
+    Freq250kHz = 6,
+    Freq125kHz = 7,
+    Freq62500Hz = 8,
+    Freq31250Hz = 9,
+}
+
+impl TimerFrequency {
+    /// Returns the value used in the PRESCALER register for this frequency.
+    ///
+    /// This is in the range 0 ..= 9.
+    pub fn as_prescaler(self) -> u32 {
+        self as u32
+    }
+
+    /// Returns a `TimerFrequency` given a value for the PRESCALER register.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `prescaler` is greater than 9.
+    pub fn from_prescaler(prescaler: u8) -> TimerFrequency {
+        match prescaler {
+            0 => TimerFrequency::Freq16MHz,
+            1 => TimerFrequency::Freq8MHz,
+            2 => TimerFrequency::Freq4MHz,
+            3 => TimerFrequency::Freq2MHz,
+            4 => TimerFrequency::Freq1MHz,
+            5 => TimerFrequency::Freq500kHz,
+            6 => TimerFrequency::Freq250kHz,
+            7 => TimerFrequency::Freq125kHz,
+            8 => TimerFrequency::Freq62500Hz,
+            9 => TimerFrequency::Freq31250Hz,
+            _ => panic!("prescaler out of range"),
+        }
+    }
+}
+
+/// A safe wrapper around an nRF51 TIMER in timer mode, with a specific
+/// counter bit-width.
+///
+/// To create a `HiResTimer` from one of the `nrf51::TIMER`*n* instances, use
+/// an appropriate trait and call one of the `as_8bit_timer()`,
+/// `as_16bit_timer()`, or `as_32bit_timer()` methods.
+///
+/// Creating a `HiResTimer` in this way stops the TIMER, sets the requested
+/// bit-width, and resets all other configuration to the defaults. In
+/// particular the counter is reset to zero and the frequency is reset to 1MHz
+/// (`Freq1MHz`).
+///
+/// Note that only TIMER0 supports 32-bit mode; the maximum bit-width for
+/// TIMER1 and TIMER2 is 16-bit.
+///
+/// `HiResTimer` doesn't support TIMER0's 24-bit mode.
+///
+/// # Examples
+///
+/// ```ignore
+/// use nrf51_hal::hi_res_timer::As8BitTimer;
+/// let p = nrf51::Peripherals::take().unwrap();
+/// let mut timer1 = p.TIMER1.as_8bit_timer();
+/// ```
+///
+/// ```ignore
+/// use nrf51_hal::hi_res_timer::As16BitTimer;
+/// let p = nrf51::Peripherals::take().unwrap();
+/// let mut timer2 = p.TIMER2.as_16bit_timer();
+/// ```
+///
+/// ```ignore
+/// use nrf51_hal::hi_res_timer::As32BitTimer;
+/// let p = nrf51::Peripherals::take().unwrap();
+/// let mut timer0 = p.TIMER0.as_32bit_timer();
+/// ```
+///
+/// ```ignore
+/// use nrf51_hal::hi_res_timer::{As16BitTimer, As32BitTimer};
+/// let p = nrf51::Peripherals::take().unwrap();
+/// let mut timer0_32 = p.TIMER0.as_32bit_timer();
+/// timer0_32.set_frequency(TimerFrequency::Freq31250Hz);
+/// timer0_32.set_compare_register(TimerCc::CC0, 2_700_000_000);
+/// timer0_32.start();
+/// while !timer0_32.poll_compare_event(TimerCc::CC0) {};
+/// timer0_32.stop();
+/// let mut timer0_16 = timer0_32.free().as_16bit_timer();
+/// ```
+
+pub struct HiResTimer<T: Nrf51Timer, Width: TimerWidth> {
+    timer: T,
+    _width: PhantomData<Width>,
+}
+
+impl<T: Nrf51Timer, Width: TimerWidth> HiResTimer<T, Width> {
+    // Private so that TIMER1 and TIMER2 can't be constructed with width u32.
+    fn new(timer: T) -> HiResTimer<T, Width> {
+        let mut h = HiResTimer {timer, _width: PhantomData};
+        // Note prescaler and bitmode must be changed only when the timer is
+        // stopped.
+        h.stop();
+        h.clear();
+        h.timer.mode.reset();
+        Width::program_timer(&h.timer);
+        h.timer.prescaler.reset();
+        h.timer.shorts.reset();
+        h.timer.cc[0].reset();
+        h.timer.cc[1].reset();
+        h.timer.cc[2].reset();
+        h.timer.cc[3].reset();
+        h.timer.events_compare[0].reset();
+        h.timer.events_compare[1].reset();
+        h.timer.events_compare[2].reset();
+        h.timer.events_compare[3].reset();
+        h.timer.intenclr.write(|w| {
+            w.compare0().clear()
+             .compare1().clear()
+             .compare2().clear()
+             .compare3().clear()
+        });
+        h
+    }
+
+    /// Stops the timer and returns the underlying `nrf51::TIMER`*n* instance.
+    ///
+    /// Other than being stopped, the TIMER is left in an unspecified state.
+    pub fn free(mut self) -> T {
+        self.stop();
+        self.timer
+    }
+
+    /// Returns the TIMER's current frequency.
+    pub fn frequency(&self) -> TimerFrequency {
+        let prescaler = self.timer.prescaler.read().prescaler().bits();
+        TimerFrequency::from_prescaler(prescaler)
+    }
+
+    /// Stops the TIMER and sets its frequency.
+    pub fn set_frequency(&mut self, frequency: TimerFrequency) {
+        let prescaler = frequency.as_prescaler();
+        self.stop();
+        self.timer.prescaler.write(|w| unsafe { w.bits(prescaler) });
+    }
+
+    /// Resets the TIMER's counter to zero.
+    ///
+    /// If the TIMER was running it will continue to run.
+    pub fn clear(&mut self) {
+        self.timer.tasks_clear.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Starts the TIMER.
+    pub fn start(&mut self) {
+        self.timer.tasks_start.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Stops the TIMER.
+    pub fn stop(&mut self) {
+        self.timer.tasks_stop.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Stops the TIMER and shuts down its power.
+    ///
+    /// This lowers power consumption, but increases the latency of the next
+    /// start.
+    pub fn shut_down(&mut self) {
+        self.timer.tasks_shutdown.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Stores a value in the specified CC register.
+    pub fn set_compare_register(&mut self, register: TimerCc, ticks: Width) {
+        self.timer.cc[register as usize].write(|w| unsafe { w.bits(ticks.into()) });
+    }
+
+    /// Stores the current counter value in the specified CC register.
+    pub fn capture(&mut self, register: TimerCc) {
+        self.timer.tasks_capture[register as usize].write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Returns the value currently stored in the specified CC register.
+    ///
+    /// Returns a u32. The value is expected to be small enough to fit in this
+    /// timer's bit-width.
+    pub fn captured_counter(&mut self, register: TimerCc) -> u32 {
+        self.timer.cc[register as usize].read().bits()
+    }
+
+    /// Returns the COMPARE event flag for the specified CC register.
+    ///
+    /// The timer sets this flag ("generates the COMPARE event") when the
+    /// counter reaches the value in the CC register.
+    pub fn read_compare_event(&self, register: TimerCc) -> bool {
+        let event_reg = &self.timer.events_compare[register as usize];
+        event_reg.read().bits() != 0
+    }
+
+    /// Clears the COMPARE event flag for the specified CC register.
+    pub fn clear_compare_event(&mut self, register: TimerCc) {
+        let event_reg = &self.timer.events_compare[register as usize];
+        event_reg.reset();
+    }
+
+    /// Checks and clears the COMPARE event flag for the specified CC register.
+    ///
+    /// Returns true if the counter has reached the value in the CC register
+    /// since this method (or `clear_compare_event()`) was last called for the
+    /// same register.
+    pub fn poll_compare_event(&mut self, register: TimerCc) -> bool {
+        let fired = self.read_compare_event(register);
+        if fired { self.clear_compare_event(register) }
+        fired
+    }
+
+    /// Enables the interrupt for the specified CC register.
+    ///
+    /// The timer's interrupt will be signalled when the register's COMPARE
+    /// event is generated.
+    ///
+    /// The interrupt handler should clear the event flag.
+    pub fn enable_compare_interrupt(&mut self, register: TimerCc) {
+        self.timer.intenset.write(|w| match register {
+            TimerCc::CC0 => w.compare0().set(),
+            TimerCc::CC1 => w.compare1().set(),
+            TimerCc::CC2 => w.compare2().set(),
+            TimerCc::CC3 => w.compare3().set(),
+        });
+    }
+
+    /// Disables the interrupt for the specified CC register.
+    pub fn disable_compare_interrupt(&mut self, register: TimerCc) {
+        self.timer.intenclr.write(|w| match register {
+            TimerCc::CC0 => w.compare0().clear(),
+            TimerCc::CC1 => w.compare1().clear(),
+            TimerCc::CC2 => w.compare2().clear(),
+            TimerCc::CC3 => w.compare3().clear(),
+        });
+    }
+
+    /// Enables the shortcut between a COMPARE event and the CLEAR task.
+    ///
+    /// When the counter reaches the value in the specified CC register, the
+    /// counter will be automatically reset to zero.
+    pub fn enable_auto_clear(&mut self, register: TimerCc) {
+        self.timer.shorts.write(|w| match register {
+            TimerCc::CC0 => w.compare0_clear().enabled(),
+            TimerCc::CC1 => w.compare1_clear().enabled(),
+            TimerCc::CC2 => w.compare2_clear().enabled(),
+            TimerCc::CC3 => w.compare3_clear().enabled(),
+        });
+    }
+
+    /// Disables the shortcut between a COMPARE event and the CLEAR task.
+    pub fn disable_auto_clear(&mut self, register: TimerCc) {
+        self.timer.shorts.write(|w| match register {
+            TimerCc::CC0 => w.compare0_clear().disabled(),
+            TimerCc::CC1 => w.compare1_clear().disabled(),
+            TimerCc::CC2 => w.compare2_clear().disabled(),
+            TimerCc::CC3 => w.compare3_clear().disabled(),
+        });
+    }
+
+    /// Enables the shortcut between a COMPARE event and the STOP task.
+    ///
+    /// When the counter reaches the value in the specified CC register, the
+    /// counter will be automatically stopped.
+    pub fn enable_auto_stop(&mut self, register: TimerCc) {
+        self.timer.shorts.write(|w| match register {
+            TimerCc::CC0 => w.compare0_stop().enabled(),
+            TimerCc::CC1 => w.compare1_stop().enabled(),
+            TimerCc::CC2 => w.compare2_stop().enabled(),
+            TimerCc::CC3 => w.compare3_stop().enabled(),
+        });
+    }
+
+    /// Disables the shortcut between a COMPARE event and the STOP task.
+    pub fn disable_auto_stop(&mut self, register: TimerCc) {
+        self.timer.shorts.write(|w| match register {
+            TimerCc::CC0 => w.compare0_stop().disabled(),
+            TimerCc::CC1 => w.compare1_stop().disabled(),
+            TimerCc::CC2 => w.compare2_stop().disabled(),
+            TimerCc::CC3 => w.compare3_stop().disabled(),
+        });
+    }
+}
+
+/// One of the nRF51's high-resolution timers, supporting an 8-bit counter
+/// (which all of them do).
+pub trait As8BitTimer: Nrf51Timer {
+    /// Takes ownership of the TIMER peripheral, returning a safe wrapper.
+    ///
+    /// Returns a `HiResTimer` in 8-bit mode.
+    fn as_8bit_timer(self) -> HiResTimer<Self, u8> {
+        HiResTimer::new(self)
+    }
+}
+
+/// One of the nRF51's high-resolution timers, supporting a 16-bit counter
+/// (which all of them do).
+pub trait As16BitTimer: Nrf51Timer {
+    /// Takes ownership of the TIMER peripheral, returning a safe wrapper.
+    ///
+    /// Returns a `HiResTimer` in 16-bit mode.
+    fn as_16bit_timer(self) -> HiResTimer<Self, u16> {
+        HiResTimer::new(self)
+    }
+}
+
+/// One of the nRF51's high-resolution timers, supporting a 32-bit counter
+/// (ie, only `nrf51::TIMER0`).
+pub trait As32BitTimer: Nrf51Timer {
+    /// Takes ownership of the TIMER peripheral, returning a safe wrapper.
+    ///
+    /// Returns a `HiResTimer` in 32-bit mode.
+    fn as_32bit_timer(self) -> HiResTimer<Self, u32> {
+        HiResTimer::new(self)
+    }
+}
+
+impl As8BitTimer for nrf51::TIMER0 {}
+impl As8BitTimer for nrf51::TIMER1 {}
+impl As8BitTimer for nrf51::TIMER2 {}
+impl As16BitTimer for nrf51::TIMER0 {}
+impl As16BitTimer for nrf51::TIMER1 {}
+impl As16BitTimer for nrf51::TIMER2 {}
+impl As32BitTimer for nrf51::TIMER0 {}
+
+impl Nrf51Timer for nrf51::TIMER0 {}
+impl Nrf51Timer for nrf51::TIMER1 {}
+impl Nrf51Timer for nrf51::TIMER2 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod ecb;
 pub mod gpio;
 pub mod hi_res_timer;
 pub mod i2c;
+pub mod lo_res_timer;
 pub mod prelude;
 pub mod rng;
 pub mod serial;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod i2c;
 pub mod prelude;
 pub mod rng;
 pub mod serial;
+pub mod time;
 pub mod timer;
 pub mod spi;
 pub mod temp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub extern crate nrf51;
 pub mod delay;
 pub mod ecb;
 pub mod gpio;
+pub mod hi_res_timer;
 pub mod i2c;
 pub mod prelude;
 pub mod rng;

--- a/src/lo_res_timer.rs
+++ b/src/lo_res_timer.rs
@@ -1,0 +1,518 @@
+//! The RTC (Real Time Counter) peripherals.
+//!
+//! This module provides a interface to the RTC peripherals, more or less
+//! directly corresponding to the underlying registers, tasks, and events.
+//!
+//! Note that in order for the RTCs to run, you must also start the
+//! low-frequency clock:
+//! ```ignore
+//! let p = nrf51::Peripherals::take().unwrap();
+//! p.CLOCK.tasks_lfclkstart.write(|w| unsafe { w.bits(1) });
+//! while p.CLOCK.events_lfclkstarted.read().bits() == 0 {}
+//! p.CLOCK.events_lfclkstarted.reset();
+//! ```
+
+use core::ops::Deref;
+
+use cast::u32;
+
+use nrf51;
+
+/// The base frequency of a RTC peripheral, in hertz.
+///
+/// This is the highest available frequency.
+pub const LFCLK_HZ: u32 = 32_768;
+
+/// One of the nRF51's low-resolution timers (`nrf51::RTC0` or `nrf51::RTC1`).
+pub trait Nrf51Rtc: Deref<Target = nrf51::rtc0::RegisterBlock> + Sized {
+    /// Returns true if the specified CC register is present on this RTC.
+    ///
+    /// RTC1 has all four registers; RTC0 is missing CC3.
+    fn has_register(register: RtcCc) -> bool;
+
+    /// Panic if this RTC doesn't have the specified CC register.
+    fn validate_register(register: RtcCc) {
+        assert!(Self::has_register(register), "register is not present");
+    }
+}
+
+/// One of the RTC Compare registers.
+///
+/// (We follow the reference manual in abbreviating these as 'CC', although
+/// they're not used for capture.)
+///
+/// Note that RTC0 doesn't have the CC3 register.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RtcCc {
+    CC0 = 0,
+    CC1 = 1,
+    CC2 = 2,
+    CC3 = 3,
+}
+
+impl RtcCc {
+    /// Returns the CC register with the specified index.
+    ///
+    /// Note you can use 'as' to go in the other direction.
+    pub fn from_index(cc: usize) -> Result<RtcCc, ()> {
+        match cc {
+            0 => Ok(RtcCc::CC0),
+            1 => Ok(RtcCc::CC1),
+            2 => Ok(RtcCc::CC2),
+            3 => Ok(RtcCc::CC3),
+            _ => Err(()),
+        }
+    }
+}
+
+/// A possible RTC frequency.
+///
+/// The hardware represents the frequency using a 12-bit prescaler value which
+/// determines the RTC's frequency as follows:
+///
+/// *frequency in Hz* = 32768 / (*prescaler* + 1)
+///
+/// Use `RtcFrequency::from_prescaler()` to create an arbitrary `RtcFrequency`
+/// from the corresponding prescaler value.
+///
+/// The `lo_res_timer::FREQ_`*nnn*`HZ` convenience constants correspond to the
+/// power-of-two submultiples of the base 32768Hz frequency:
+///
+/// Frequency      | Period   | Overflow
+/// -------------- | -------- | ---------
+/// `FREQ_32768HZ` | ~30.5µs  | 512 seconds
+/// `FREQ_16384HZ` | ~61µs    | over 17 minutes
+/// `FREQ_8192HZ`  | ~122µs   | over 34 minutes
+/// `FREQ_4096HZ`  | ~244µs   | over 68 minutes
+/// `FREQ_2048HZ`  | ~488µs   | over 136 minutes
+/// `FREQ_1024HZ`  | ~977µs   | over 4.5 hours
+/// `FREQ_512HZ`   | ~1.95ms  | over 9 hours
+/// `FREQ_256HZ`   | ~3.9ms   | over 18 hours
+/// `FREQ_128HZ`   | ~7.8ms   | over 36 hours
+/// `FREQ_64HZ`    | 15.625ms | over 3 days
+/// `FREQ_32HZ`    | 31.25ms  | over 6 days
+/// `FREQ_16HZ`    | 62.5ms   | over 12 days
+/// `FREQ_8HZ`     | 125ms    | over 24 days
+///
+/// # Examples
+///
+/// ```
+/// let frequency = RtcFrequency::new(327); // 99.9Hz
+/// let frequency = FREQ_32768HZ;
+/// let frequency = FREQ_8HZ;
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct RtcFrequency(u16);
+
+impl RtcFrequency {
+    /// Returns an `RtcFrequency` with the specified prescaler value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the supplied value is ≥ 2^12 (4096).
+    pub fn from_prescaler<T: Into<u32>>(i: T) -> RtcFrequency {
+        let i = i.into();
+        assert!(i < 1 << 12, "prescaler value out of range");
+        RtcFrequency(i as u16)
+    }
+
+    const fn const_from_prescaler(i: u16) -> RtcFrequency {
+        RtcFrequency(i)
+    }
+
+    /// Returns the prescaler value.
+    pub fn as_prescaler(self) -> u32 {
+        self.0 as u32
+    }
+
+    /// Apply the effective prescaler value.
+    ///
+    /// Converts a number of ticks of the base 32768Hz clock to the equivalent
+    /// number of ticks for an RTC using this frequency.
+    ///
+    /// Rounds down.
+    ///
+    /// Returns `None` if the result doesn't fit in a u32 (but note that if
+    /// the result doesn't fit in 24 bits it can't be used directly).
+    pub fn scale(self, base_ticks: u64) -> Option<u32> {
+        u32(base_ticks / (self.0 + 1) as u64).ok()
+    }
+}
+
+/// RTC frequency 32768Hz
+pub const FREQ_32768HZ: RtcFrequency = RtcFrequency::const_from_prescaler(0);
+
+/// RTC frequency 16384Hz
+pub const FREQ_16384HZ: RtcFrequency = RtcFrequency::const_from_prescaler(1);
+
+/// RTC frequency 8192Hz
+pub const FREQ_8192HZ: RtcFrequency = RtcFrequency::const_from_prescaler(3);
+
+/// RTC frequency 4096Hz
+pub const FREQ_4096HZ: RtcFrequency = RtcFrequency::const_from_prescaler(7);
+
+/// RTC frequency 2048Hz
+pub const FREQ_2048HZ: RtcFrequency = RtcFrequency::const_from_prescaler(15);
+
+/// RTC frequency 1024Hz
+pub const FREQ_1024HZ: RtcFrequency = RtcFrequency::const_from_prescaler(31);
+
+/// RTC frequency 512Hz
+pub const FREQ_512HZ: RtcFrequency = RtcFrequency::const_from_prescaler(63);
+
+/// RTC frequency 256Hz
+pub const FREQ_256HZ: RtcFrequency = RtcFrequency::const_from_prescaler(127);
+
+/// RTC frequency 128Hz
+pub const FREQ_128HZ: RtcFrequency = RtcFrequency::const_from_prescaler(255);
+
+/// RTC frequency 64Hz
+pub const FREQ_64HZ: RtcFrequency = RtcFrequency::const_from_prescaler(511);
+
+/// RTC frequency 32Hz
+pub const FREQ_32HZ: RtcFrequency = RtcFrequency::const_from_prescaler(1023);
+
+/// RTC frequency 16Hz
+pub const FREQ_16HZ: RtcFrequency = RtcFrequency::const_from_prescaler(2047);
+
+/// RTC frequency 8Hz
+pub const FREQ_8HZ: RtcFrequency = RtcFrequency::const_from_prescaler(4095);
+
+/// A safe wrapper around an nRF51 RTC (Real Time Counter) peripheral.
+///
+/// Both RTC peripherals have a fixed counter width of 24 bits.
+///
+/// Note that when a request is made to start or stop the counter it will take
+/// effect after a delay of 15 to 46 µs. See the nRF51 Series Reference Manual
+/// for details.
+///
+/// # Panics
+///
+/// All methods taking a `RtcCc` parameter will panic if `CC3` is passed and
+/// the underlying peripheral is RTC0.
+///
+/// # Examples
+///
+/// ```ignore
+/// use nrf51_hal::lo_res_timer::{LoResTimer, FREQ_1024HZ};
+/// let p = nrf51::Peripherals::take().unwrap();
+/// let mut rtc0 = LoResTimer::new(p.RTC0);
+/// rtc0.set_frequency(FREQ_1024HZ);
+/// rtc0.set_compare_register(RtcCc::CC0, 512);
+/// rtc0.start();
+/// while !rtc0.poll_compare_event(RtcrCc::CC0) {};
+/// rtc0.stop();
+/// ```
+pub struct LoResTimer<T: Nrf51Rtc> {
+    rtc: T,
+}
+
+impl<T: Nrf51Rtc> LoResTimer<T> {
+    /// Takes ownership of the RTC peripheral, returning a safe wrapper.
+    ///
+    /// Stops the RTC and resets all other configuration to the defaults. In
+    /// particular all events are disabled, the counter is reset to zero, and
+    /// the prescaler is reset from `FREQ_32768HZ`.
+    pub fn new(rtc: T) -> LoResTimer<T> {
+        let mut l = LoResTimer { rtc };
+        // Note prescaler should be changed only when the timer is stopped.
+        l.stop();
+        l.clear();
+        l.rtc.prescaler.reset();
+        l.rtc.cc[0].reset();
+        l.rtc.cc[1].reset();
+        l.rtc.cc[2].reset();
+        if T::has_register(RtcCc::CC3) {
+            l.rtc.cc[3].reset();
+        }
+        l.rtc.events_tick.reset();
+        l.rtc.events_ovrflw.reset();
+        l.rtc.events_compare[0].reset();
+        l.rtc.events_compare[1].reset();
+        l.rtc.events_compare[2].reset();
+        if T::has_register(RtcCc::CC3) {
+            l.rtc.events_compare[3].reset();
+        }
+        l.rtc.evtenclr.write(|w| {
+            let w = w
+                .tick().clear()
+                .ovrflw().clear()
+                .compare0().clear()
+                .compare1().clear()
+                .compare2().clear();
+            if T::has_register(RtcCc::CC3) {
+                w.compare3().clear()
+            } else {
+                w
+            }
+        });
+        l.rtc.intenclr.write(|w| {
+            let w = w
+                .tick().clear()
+                .ovrflw().clear()
+                .compare0().clear()
+                .compare1().clear()
+                .compare2().clear();
+            if T::has_register(RtcCc::CC3) {
+                w.compare3().clear()
+            } else {
+                w
+            }
+        });
+        l
+    }
+
+    /// Stops the RTC and returns the underlying `nrf51::RTC`*n* instance.
+    ///
+    /// Other than being stopped, the RTC is left in an unspecified state.
+    pub fn free(mut self) -> T {
+        self.stop();
+        self.rtc
+    }
+
+    /// Returns the RTC's current frequency by reading the prescaler register.
+    pub fn frequency(&self) -> RtcFrequency {
+        RtcFrequency::from_prescaler(self.rtc.prescaler.read().prescaler().bits())
+    }
+
+    /// Stops the RTC and sets its frequency.
+    ///
+    /// Writes the prescaler register.
+    pub fn set_frequency(&mut self, frequency: RtcFrequency) {
+        self.stop();
+        self.rtc.prescaler.write(|w| unsafe { w.bits(frequency.as_prescaler()) });
+    }
+
+    /// Returns the RTC's current counter value.
+    pub fn read_counter(&self) -> u32 {
+        self.rtc.counter.read().counter().bits()
+    }
+
+    /// Stores a value in the specified CC register.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ticks` is ≥ 2^24.
+    pub fn set_compare_register(&mut self, register: RtcCc, ticks: u32) {
+        T::validate_register(register);
+        assert!(ticks < 1 << 24, "register value out of range");
+        self.rtc.cc[register as usize].write(|w| unsafe { w.bits(ticks) });
+    }
+
+    /// Resets the RTC's counter to zero.
+    ///
+    /// If the RTC was running it will continue to run.
+    pub fn clear(&mut self) {
+        self.rtc.tasks_clear.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Starts the RTC.
+    pub fn start(&mut self) {
+        self.rtc.tasks_start.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Stops the RTC.
+    pub fn stop(&mut self) {
+        self.rtc.tasks_stop.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Sets the RTC's counter value to 0xFFFFF0.
+    ///
+    /// This will cause it to overflow shortly afterwards.
+    pub fn trigger_overflow(&mut self) {
+        self.rtc.tasks_trigovrflw.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Enables the COMPARE event for the specified CC register.
+    ///
+    /// The event is generated when the counter reaches the value in the CC
+    /// register.
+    pub fn enable_compare_event(&mut self, register: RtcCc) {
+        T::validate_register(register);
+        self.rtc.evtenset.write(|w| match register {
+            RtcCc::CC0 => w.compare0().set(),
+            RtcCc::CC1 => w.compare1().set(),
+            RtcCc::CC2 => w.compare2().set(),
+            RtcCc::CC3 => w.compare3().set(),
+        });
+    }
+
+    /// Disables the COMPARE event for the specified CC register.
+    pub fn disable_compare_event(&mut self, register: RtcCc) {
+        T::validate_register(register);
+        self.rtc.evtenclr.write(|w| match register {
+            RtcCc::CC0 => w.compare0().clear(),
+            RtcCc::CC1 => w.compare1().clear(),
+            RtcCc::CC2 => w.compare2().clear(),
+            RtcCc::CC3 => w.compare3().clear(),
+        });
+    }
+
+    /// Enables the TICK event.
+    ///
+    /// The event is generated each time the RTC's counter increases.
+    pub fn enable_tick_event(&mut self) {
+        self.rtc.evtenset.write(|w| w.tick().set());
+    }
+
+    /// Disables the TICK event.
+    pub fn disable_tick_event(&mut self) {
+        self.rtc.evtenclr.write(|w| w.tick().clear());
+    }
+
+    /// Enables the OVRFLW event.
+    ///
+    /// The event is generated when the RTC's counter overflows from 0xFFFFFF
+    /// to 0.
+    pub fn enable_overflow_event(&mut self) {
+        self.rtc.evtenset.write(|w| w.ovrflw().set());
+    }
+
+    /// Disables the OVRFLW event.
+    pub fn disable_overflow_event(&mut self) {
+        self.rtc.evtenclr.write(|w| w.ovrflw().clear());
+    }
+
+    /// Enables the interrupt for the specified CC register.
+    ///
+    /// The RTC's interrupt will be signalled when the register's COMPARE
+    /// event is generated.
+    ///
+    /// Note the event must be enabled separately.
+    ///
+    /// The interrupt handler should clear the event flag.
+    pub fn enable_compare_interrupt(&mut self, register: RtcCc) {
+        T::validate_register(register);
+        self.rtc.intenset.write(|w| match register {
+            RtcCc::CC0 => w.compare0().set(),
+            RtcCc::CC1 => w.compare1().set(),
+            RtcCc::CC2 => w.compare2().set(),
+            RtcCc::CC3 => w.compare3().set(),
+        });
+    }
+
+    /// Disables the interrupt for the specified CC register.
+    pub fn disable_compare_interrupt(&mut self, register: RtcCc) {
+        T::validate_register(register);
+        self.rtc.intenclr.write(|w| match register {
+            RtcCc::CC0 => w.compare0().clear(),
+            RtcCc::CC1 => w.compare1().clear(),
+            RtcCc::CC2 => w.compare2().clear(),
+            RtcCc::CC3 => w.compare3().clear(),
+        });
+    }
+
+    /// Enables the interrupt for the TICK event.
+    ///
+    /// The RTC's interrupt will be signalled when the TICK event is generated.
+    ///
+    /// Note the event must be enabled separately.
+    ///
+    /// The interrupt handler should clear the event flag.
+    pub fn enable_tick_interrupt(&mut self) {
+        self.rtc.intenset.write(|w| w.tick().set());
+    }
+
+    /// Disables the interrupt for the TICK event.
+    pub fn disable_tick_interrupt(&mut self) {
+        self.rtc.intenclr.write(|w| w.tick().clear());
+    }
+
+    /// Enables the interrupt for the OVRFLW event.
+    ///
+    /// The RTC's interrupt will be signalled when the OVRFLW event is
+    /// generated.
+    ///
+    /// Note the event must be enabled separately.
+    ///
+    /// The interrupt handler should clear the event flag.
+    pub fn enable_overflow_interrupt(&mut self) {
+        self.rtc.intenset.write(|w| w.ovrflw().set());
+    }
+
+    /// Disables the interrupt for the OVRFLW event.
+    pub fn disable_overflow_interrupt(&mut self) {
+        self.rtc.intenclr.write(|w| w.ovrflw().clear());
+    }
+
+    /// Returns the COMPARE event flag for the specified CC register.
+    ///
+    /// The RTC sets this flag ("generates the COMPARE event") when the event
+    /// is enabled and the counter reaches the value in the CC register.
+    pub fn read_compare_event(&self, register: RtcCc) -> bool {
+        let event_reg = &self.rtc.events_compare[register as usize];
+        event_reg.read().bits() != 0
+    }
+
+    /// Clears the COMPARE event flag for the specified CC register.
+    pub fn clear_compare_event(&mut self, register: RtcCc) {
+        let event_reg = &self.rtc.events_compare[register as usize];
+        event_reg.reset();
+    }
+
+    /// Checks and clears the COMPARE event flag for the specified CC register.
+    ///
+    /// Returns true if the counter has reached the value in the CC register
+    /// (and the event is enabled) since this method (or
+    /// `clear_compare_event()`) was last called for the same register.
+    pub fn poll_compare_event(&mut self, register: RtcCc) -> bool {
+        T::validate_register(register);
+        let fired = self.read_compare_event(register);
+        if fired { self.clear_compare_event(register) }
+        fired
+    }
+
+    /// Returns the TICK event flag.
+    pub fn read_tick_event(&self) -> bool {
+        self.rtc.events_tick.read().bits() != 0
+    }
+
+    /// Clears the TICK event flag.
+    pub fn clear_tick_event(&mut self) {
+        self.rtc.events_tick.reset();
+    }
+
+    /// Checks and clears the TICK event flag.
+    ///
+    /// Returns true if the TICK event has occurred (and the event is enabled)
+    /// since this method (or `clear_tick_event()`) was last called.
+    pub fn poll_tick_event(&mut self) -> bool {
+        let fired = self.read_tick_event();
+        if fired { self.clear_tick_event() }
+        fired
+    }
+
+    /// Returns the OVRFLW event flag.
+    pub fn read_overflow_event(&self) -> bool {
+        self.rtc.events_ovrflw.read().bits() != 0
+    }
+
+    /// Clears the OVRFLW event flag.
+    pub fn clear_overflow_event(&mut self) {
+        self.rtc.events_ovrflw.reset();
+    }
+
+    /// Checks and clears the OVRFLW event flag.
+    ///
+    /// Returns true if the OVRFLW event has occurred (and the event is
+    /// enabled) since this method (or `clear_overflow_event()`) was last
+    /// called.
+    pub fn poll_overflow_event(&mut self) -> bool {
+        let fired = self.read_overflow_event();
+        if fired { self.clear_overflow_event() }
+        fired
+    }
+}
+
+impl Nrf51Rtc for nrf51::RTC0 {
+    fn has_register(register: RtcCc) -> bool {
+        register != RtcCc::CC3
+    }
+}
+
+impl Nrf51Rtc for nrf51::RTC1 {
+    #[allow(unused_variables)]
+    fn has_register(register: RtcCc) -> bool {
+        true
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -62,6 +62,24 @@ impl From<Duration> for Hfticks {
 #[derive(Debug, Clone, Copy)]
 pub struct Lfticks(pub u64);
 
+/// Converts a core::time::Duration to a number of ticks of the low-frequency
+/// clock.
+///
+/// Rounds down.
+///
+/// # Panics
+///
+/// Panics if the duration is longer than 2^32-1 seconds
+impl From<Duration> for Lfticks {
+    fn from(duration: Duration) -> Self {
+        let secs = u32(duration.as_secs()).expect("duration too long");
+        Lfticks(
+            duration.subsec_nanos() as u64 * LFCLK_HZ as u64 / 1_000_000_000 +
+            secs as u64 * LFCLK_HZ as u64
+        )
+    }
+}
+
 impl Lfticks {
     /// Converts a time in milliseconds to a number of ticks of the
     /// low-frequency clock.

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,28 @@
+//! Time conversions for the high frequency clock.
+
+use crate::hi_res_timer::HFCLK_MHZ;
+
+
+/// A number of ticks of the nRF51 high-frequency clock (HFCLK).
+///
+/// The clock frequency is 16MHz, so each tick is 62.5ns.
+///
+/// All TIMER frequencies are a multiple of this base frequency.
+///
+/// Holds a 64-bit number.
+#[derive(Debug, Clone, Copy)]
+pub struct Hfticks(pub u64);
+
+impl Hfticks {
+    /// Converts a time in milliseconds to an exact number of ticks of the
+    /// high-frequency clock.
+    pub fn from_ms(ms: u32) -> Hfticks {
+        Hfticks(ms as u64 * HFCLK_MHZ as u64 * 1000)
+    }
+
+    /// Converts a time in microseconds to an exact number of ticks of the
+    /// high-frequency clock.
+    pub fn from_us(us: u32) -> Hfticks {
+        Hfticks(us as u64 * HFCLK_MHZ as u64)
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,5 +1,9 @@
 //! Time conversions for the high frequency clock.
 
+use core::time::Duration;
+
+use cast::u32;
+
 use crate::hi_res_timer::HFCLK_MHZ;
 
 
@@ -24,5 +28,23 @@ impl Hfticks {
     /// high-frequency clock.
     pub fn from_us(us: u32) -> Hfticks {
         Hfticks(us as u64 * HFCLK_MHZ as u64)
+    }
+}
+
+/// Converts a core::time::Duration to a number of ticks of the high-frequency
+/// clock.
+///
+/// Rounds down.
+///
+/// # Panics
+///
+/// Panics if the duration is longer than 2^32-1 seconds
+impl From<Duration> for Hfticks {
+    fn from(duration: Duration) -> Self {
+        let secs = u32(duration.as_secs()).expect("duration too long");
+        Hfticks(
+            duration.subsec_nanos() as u64 * HFCLK_MHZ as u64 / 1000 +
+            secs as u64 * HFCLK_MHZ as u64 * 1_000_000
+        )
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,10 +1,11 @@
-//! Time conversions for the high frequency clock.
+//! Time conversions for the high and low frequency clocks.
 
 use core::time::Duration;
 
 use cast::u32;
 
 use crate::hi_res_timer::HFCLK_MHZ;
+use crate::lo_res_timer::LFCLK_HZ;
 
 
 /// A number of ticks of the nRF51 high-frequency clock (HFCLK).
@@ -48,3 +49,34 @@ impl From<Duration> for Hfticks {
         )
     }
 }
+
+
+/// A number of ticks of the nRF51 low-frequency clock (LFCLK).
+///
+/// The clock frequency is 32.768kHz, so each tick is approximately 30.5
+/// microseconds.
+///
+/// All RTC frequencies are a multiple of this base frequency.
+///
+/// Holds a 64-bit number.
+#[derive(Debug, Clone, Copy)]
+pub struct Lfticks(pub u64);
+
+impl Lfticks {
+    /// Converts a time in milliseconds to a number of ticks of the
+    /// low-frequency clock.
+    ///
+    /// Rounds down.
+    pub fn from_ms(ms: u32) -> Lfticks {
+        Lfticks((ms as u64 * LFCLK_HZ as u64) / 1_000)
+    }
+
+    /// Converts a time in microseconds to a number of ticks of the
+    /// low-frequency clock.
+    ///
+    /// Rounds down.
+    pub fn from_us(us: u32) -> Lfticks {
+        Lfticks((us as u64 * LFCLK_HZ as u64) / 1_000_000)
+    }
+}
+

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,3 +1,5 @@
+//! Implementation of the embedded-hal `CountDown` trait.
+
 use core::time::Duration;
 use core::u32;
 
@@ -7,17 +9,40 @@ use hal::timer::{CountDown, Periodic};
 use nb::{Error, Result};
 use nrf51::TIMER0;
 
-pub struct Timer(TIMER0);
+use crate::hi_res_timer::{HiResTimer, As32BitTimer, TimerCc};
+
+/// System timer `TIMER0` as a `CountDown` provider.
+///
+/// This is a 32-bit timer running at 1MHz, giving a maximum setting of
+/// approximately 71 minutes.
+///
+/// `Timer` instances implement the embedded-hal `CountDown` trait.
+///
+/// `start()` accepts a `Duration` value.
+///
+/// The timer is periodic (it implements the `Periodic` trait).
+///
+/// Calling `start()` more than once is permitted (whether or not `wait()` has
+/// already been called).
+///
+/// # Panics
+///
+/// `start()` panics if the requested time exceeds the maximum setting.
+pub struct Timer(HiResTimer<TIMER0, u32>);
 
 impl Timer {
+    /// Returns a new `Timer` wrapping TIMER0.
+    ///
+    /// Takes ownership of the TIMER0 peripheral.
     pub fn new(timer: TIMER0) -> Timer {
-        // 32bits @ 1MHz == max delay of ~1 hour 11 minutes
-        timer.bitmode.write(|w| w.bitmode()._32bit());
-        timer.prescaler.write(|w| unsafe { w.prescaler().bits(4) });
-        timer.intenset.write(|w| w.compare0().set());
-        timer.shorts.write(|w| w.compare0_clear().enabled());
+        let mut hi_res_timer = timer.as_32bit_timer();
+        hi_res_timer.enable_auto_clear(TimerCc::CC0);
+        Timer(hi_res_timer)
+    }
 
-        Timer(timer)
+    /// Gives the underlying `nrf51::TIMER0` instance back.
+    pub fn free(self) -> TIMER0 {
+        self.0.free()
     }
 }
 
@@ -30,21 +55,19 @@ impl CountDown for Timer {
     {
         let duration = count.into();
         assert!(duration.as_secs() < u64::from((u32::MAX - duration.subsec_micros()) / 1_000_000));
-
         let us = (duration.as_secs() as u32) * 1_000_000 + duration.subsec_micros();
         // Stop the timer to make sure the event doesn't occur while we're
         // setting things up (if start() is called more than once).
-        self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
-        self.0.cc[0].write(|w| unsafe { w.bits(us) });
-
-        self.0.events_compare[0].reset();
-        self.0.tasks_clear.write(|w| unsafe { w.bits(1) });
-        self.0.tasks_start.write(|w| unsafe { w.bits(1) });
+        self.0.stop();
+        self.0.clear_compare_event(TimerCc::CC0);
+        // Default frequency is 1MHz, so we can use microseconds as ticks
+        self.0.set_compare_register(TimerCc::CC0, us);
+        self.0.clear();
+        self.0.start();
     }
 
     fn wait(&mut self) -> Result<(), Void> {
-        if self.0.events_compare[0].read().bits() == 1 {
-            self.0.events_compare[0].reset();
+        if self.0.poll_compare_event(TimerCc::CC0) {
             Ok(())
         } else {
             Err(Error::WouldBlock)

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -9,7 +9,91 @@ use hal::timer::{CountDown, Periodic};
 use nb::{Error, Result};
 use nrf51::TIMER0;
 
-use crate::hi_res_timer::{HiResTimer, As32BitTimer, TimerCc};
+use crate::hi_res_timer::{HiResTimer, Nrf51Timer, TimerCc, TimerWidth};
+
+/// A TIMER peripheral as a `CountDown` provider.
+///
+/// `CountDownTimer` instances implement the embedded-hal `CountDown` trait.
+///
+/// `start()` accepts a `Duration` value.
+///
+/// The timer is periodic (it implements the `Periodic` trait).
+///
+/// Calling `start()` more than once is permitted (whether or not `wait()` has
+/// already been called).
+///
+/// # Panics
+///
+/// `start()` panics if the requested time requires more 1mHz ticks than can
+/// be represented using the timer's bit-width (32-bit for TIMER0, giving
+/// approximately 71 minutes; 16-bit otherwise, giving approximately 65ms).
+///
+/// # Example
+/// ```
+/// use core::time::Duration;
+/// use embedded_hal::timer::CountDown;
+/// use nb::block;
+/// use nrf51_hal::timer::CountdownTimer;
+/// let p = nrf51::Peripherals::take().unwrap();
+/// let mut timer0 = CountDownTimer::new(p.TIMER0);
+/// CountDown::start(&mut timer0, Duration::from_millis(1500));
+/// block!(timer0.wait());
+/// ```
+pub struct CountDownTimer<T: Nrf51Timer> {
+    timer: HiResTimer<T, T::MaxWidth>,
+}
+
+impl<T: Nrf51Timer> CountDownTimer<T> {
+    /// Returns a new `CountDownTimer` wrapping the passed TIMER.
+    ///
+    /// Takes ownership of the TIMER peripheral.
+    ///
+    /// The TIMER is set to the greatest bit-width it supports, and the
+    /// default 1MHz frequency.
+    pub fn new(timer: T) -> CountDownTimer<T> {
+        let mut hi_res_timer = timer.as_max_width_timer();
+        hi_res_timer.enable_auto_clear(TimerCc::CC0);
+        CountDownTimer { timer: hi_res_timer }
+    }
+
+    /// Gives the underlying `nrf51::TIMER`*n* instance back.
+    pub fn free(self) -> T {
+        self.timer.free()
+    }
+}
+
+impl<T: Nrf51Timer> CountDown for CountDownTimer<T> {
+    type Time = Duration;
+
+    fn start<D>(&mut self, count: D)
+    where
+        D: Into<Self::Time>,
+    {
+        let duration = count.into();
+        assert!(duration.as_secs() < u64::from((u32::MAX - duration.subsec_micros()) / 1_000_000));
+        let us = (duration.as_secs() as u32) * 1_000_000 + duration.subsec_micros();
+        // Default frequency is 1MHz, so we can use microseconds as ticks
+        let ticks = T::MaxWidth::try_from_u32(us).expect("TIMER compare value too wide");
+        // Stop the timer to make sure the event doesn't occur while we're
+        // setting things up (if start() is called more than once).
+        self.timer.stop();
+        self.timer.clear_compare_event(TimerCc::CC0);
+        self.timer.set_compare_register(TimerCc::CC0, ticks);
+        self.timer.clear();
+        self.timer.start();
+    }
+
+    fn wait(&mut self) -> Result<(), Void> {
+        if self.timer.poll_compare_event(TimerCc::CC0) {
+            Ok(())
+        } else {
+            Err(Error::WouldBlock)
+        }
+    }
+}
+
+impl<T: Nrf51Timer> Periodic for CountDownTimer<T> {}
+
 
 /// System timer `TIMER0` as a `CountDown` provider.
 ///
@@ -28,51 +112,4 @@ use crate::hi_res_timer::{HiResTimer, As32BitTimer, TimerCc};
 /// # Panics
 ///
 /// `start()` panics if the requested time exceeds the maximum setting.
-pub struct Timer(HiResTimer<TIMER0, u32>);
-
-impl Timer {
-    /// Returns a new `Timer` wrapping TIMER0.
-    ///
-    /// Takes ownership of the TIMER0 peripheral.
-    pub fn new(timer: TIMER0) -> Timer {
-        let mut hi_res_timer = timer.as_32bit_timer();
-        hi_res_timer.enable_auto_clear(TimerCc::CC0);
-        Timer(hi_res_timer)
-    }
-
-    /// Gives the underlying `nrf51::TIMER0` instance back.
-    pub fn free(self) -> TIMER0 {
-        self.0.free()
-    }
-}
-
-impl CountDown for Timer {
-    type Time = Duration;
-
-    fn start<T>(&mut self, count: T)
-    where
-        T: Into<Self::Time>,
-    {
-        let duration = count.into();
-        assert!(duration.as_secs() < u64::from((u32::MAX - duration.subsec_micros()) / 1_000_000));
-        let us = (duration.as_secs() as u32) * 1_000_000 + duration.subsec_micros();
-        // Stop the timer to make sure the event doesn't occur while we're
-        // setting things up (if start() is called more than once).
-        self.0.stop();
-        self.0.clear_compare_event(TimerCc::CC0);
-        // Default frequency is 1MHz, so we can use microseconds as ticks
-        self.0.set_compare_register(TimerCc::CC0, us);
-        self.0.clear();
-        self.0.start();
-    }
-
-    fn wait(&mut self) -> Result<(), Void> {
-        if self.0.poll_compare_event(TimerCc::CC0) {
-            Ok(())
-        } else {
-            Err(Error::WouldBlock)
-        }
-    }
-}
-
-impl Periodic for Timer {}
+pub type Timer = CountDownTimer<TIMER0>;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -32,6 +32,9 @@ impl CountDown for Timer {
         assert!(duration.as_secs() < u64::from((u32::MAX - duration.subsec_micros()) / 1_000_000));
 
         let us = (duration.as_secs() as u32) * 1_000_000 + duration.subsec_micros();
+        // Stop the timer to make sure the event doesn't occur while we're
+        // setting things up (if start() is called more than once).
+        self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
         self.0.cc[0].write(|w| unsafe { w.bits(us) });
 
         self.0.events_compare[0].reset();


### PR DESCRIPTION
Includes standalone modules for the TIMER and RTC peripherals exposing most but not all of their functionality (the main missing feature is the TIMERs' counter mode).

Provides new implementations of the embedded-hal `CountDown` and `Delay` traits based on these modules.

These support using all three TIMERs, or either RTC, at any frequency supported by the hardware.

Includes backwards-compatible `timer::Timer` and `delay::Delay` types.

The approach is loosely based on PR #12 but the implementation is new, with the 'driver' code separated from the countdown/delay support, and no macros.

The hardware restriction to no more than 16-bit mode for TIMER1 and TIMER2 is enforced statically.

There are usage examples in the rustdoc and in `test_timer.rs` and `test_countdown.rs` on the [mattheww/microbit timer-test-examples branch](https://github.com/mattheww/microbit/tree/timer-test-examples) (which is based on the [droogmic/microbit timer-rtc branch](https://github.com/droogmic/microbit/tree/timer-rtc)).

